### PR TITLE
[NO MERGE] cdelta merge

### DIFF
--- a/src/squashmerge.c
+++ b/src/squashmerge.c
@@ -384,8 +384,8 @@ int run_xdelta3(struct mmap_file* patch, struct mmap_file* output,
 			exit(1);
 		}
 
-		if (execlp("xdelta3",
-					"xdelta3", "-c", "-d", "-s", input_path, 0) == -1)
+		if (execlp("cdelta",
+				   "cdelta", "merge", "-d", "delta.cdel", "-o", "file.txt", "-s", input_path, 0) == -1)
 		{
 			fprintf(stderr, "execlp() failed\n"
 					"\terrno: %s\n", strerror(errno));


### PR DESCRIPTION
This replaces xdelta with cdelta for merging files. This needs to be fixed in two ways:

1. Figure out how to deal with the output file. Basically, xdelta3 is able to output the merged file to stdout. Corlindelta is not able to do this from a core part of its design. Basically, xdelta3 keeps a huge amount of data in memory so that it can output to stdout and still reference previous data. cdelta needs to skip back in the output file, which is not supported on stdout so it can only be done by merging out to a file. This shouldn't be a huge problem to implement but we do need to figure it out.

2. cdelta should be change to be enabled as a flag on squashmerge, and the device will have to know which one to use somehow.